### PR TITLE
fix: Remove comment in TLD file

### DIFF
--- a/tools/make_tld_list.py
+++ b/tools/make_tld_list.py
@@ -12,7 +12,9 @@ def get_content(url: str) -> str:
 
 
 def main() -> None:
-    content = get_content("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+    raw_content = get_content("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+    lines = raw_content.split("\n")
+    content = "\n".join(lines[1 : len(lines)])
     with open("./wordlists/discovery/tlds.txt", "w+", encoding="utf-8") as manuf_file:
         manuf_file.write(content)
 

--- a/wordlists/discovery/tlds.txt
+++ b/wordlists/discovery/tlds.txt
@@ -1,4 +1,3 @@
-# Version 2023101002, Last Updated Wed Oct 11 07:07:02 2023 UTC
 AAA
 AARP
 ABB


### PR DESCRIPTION
Not ignoring this comment leads to unnecessary commits like [`a241216`](https://github.com/kkrypt0nn/wordlists/commit/a241216d2b7bbcce9f18dc5dac2b84b3bec13519), [`e6ab4ef`](https://github.com/kkrypt0nn/wordlists/commit/e6ab4ef410261f7c18f71e078b49b618a79c1b91) or [`c8e1c96`](https://github.com/kkrypt0nn/wordlists/commit/c8e1c9632b113fcc61301efa01ae82878ab8a9f7).

At first I though I'd get only updated whenever they actually *update* the content..